### PR TITLE
docs: fixed typo flexbility  --> flexibility

### DIFF
--- a/website/pages/docs/guides/class-name-prop.mdx
+++ b/website/pages/docs/guides/class-name-prop.mdx
@@ -33,7 +33,7 @@ import { twMerge } from "tailwind-merge";
 import { clsx } from "clsx";
 import { createTwc } from "react-twc";
 
-// Using `clsx` + `twMerge` for a complete flexbility (taken from shadcn/ui)
+// Using `clsx` + `twMerge` for a complete flexibility (taken from shadcn/ui)
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
## Summary

docs update - fixed typo flexbility  --> flexibility in `/docs/guides/class-name-prop.mdx`


## Test plan
<img width="1434" alt="Screenshot 2023-12-22 at 06 25 18" src="https://github.com/gregberge/twc/assets/11736897/481681de-391f-4bd5-b458-733522c7a535">
