### PR TITLE
Rename classed-components to styled-components

### DIFF
--- a/website/pages/docs/faq.mdx
+++ b/website/pages/docs/faq.mdx
@@ -8,6 +8,6 @@ Yes, even if `react-twc` has been created to solve Tailwind + React productivity
 
 No, props interpolations are not supported. I tried to make this utility as small as possible and I don't see a real advantage over passing the function at the top level.
 
-## What are the difference other libraries like `classed-components`?
+## What are the differences between other libraries like `styled-components`?
 
 `react-twc` is not a simple port of `styled-components` for classes. I tried to create it with today's practices and to keep it as small as possible. I added some very useful features like the support of `asChild` or the ability to specify your own compose function.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
It's about this line in the FAQ page: _What are the difference other libraries like `classed-components`?_

I don't know if `classed-components` is meant to be `styled-components` because in the answer you referenced `styled-components`.

So I renamed it 😀
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
