### PR TITLE
fix: fix generic typings

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -43,11 +43,11 @@ describe("twc", () => {
     expect(title.classList.contains("font-medium")).toBe(true);
   });
 
-  test("accepts custom props", () => {
+  test("accepts additional props", () => {
     type TitleProps = { children: React.ReactNode; className?: string };
     const Title = twc.h1<TitleProps>`text-xl`;
     render(
-      // @ts-expect-error `title` is not a valid prop
+      // title should still be a valid prop as its inherited from h1
       <Title className="font-medium" title="x">
         Title
       </Title>,
@@ -96,7 +96,7 @@ describe("twc", () => {
   });
 
   test("works with cva", () => {
-    const button = cva(["font-semibold", "border", "rounded"], {
+    const buttonVariants = cva(["font-semibold", "border", "rounded"], {
       variants: {
         $intent: {
           primary: ["bg-blue-500", "text-white"],
@@ -109,10 +109,10 @@ describe("twc", () => {
     });
 
     type ButtonProps = React.ComponentProps<"button"> &
-      VariantProps<typeof button>;
+      VariantProps<typeof buttonVariants>;
 
     const Button = twc.button<ButtonProps>(({ $intent }) =>
-      button({ $intent }),
+      buttonVariants({ $intent }),
     );
 
     render(
@@ -139,6 +139,39 @@ describe("twc", () => {
     expect(title).toBeDefined();
     expect(title.tagName).toBe("H2");
     expect(title.classList.contains("text-xl")).toBe(true);
+  });
+
+  test("works with cva and asChild", () => {
+    const titleVariants = cva("text-xl", {
+      variants: {
+        $intent: {
+          primary: ["font-extrabold"],
+          secondary: ["font-bold"],
+        },
+      },
+      defaultVariants: {
+        $intent: "primary",
+      },
+    });
+
+    type TitleProps = React.ComponentProps<"h1"> &
+      VariantProps<typeof titleVariants>;
+
+    const Title = twc.button<TitleProps>(({ $intent }) =>
+      titleVariants({ $intent }),
+    );
+
+    render(
+      <Title $intent="secondary" asChild>
+        <h2>Title</h2>
+      </Title>,
+    );
+    const title = screen.getByText("Title");
+    expect(title).toBeDefined();
+    expect(title.tagName).toBe("H2");
+    expect(title.getAttribute("$intent")).toBe(null);
+    expect(title.classList.contains("text-xl")).toBe(true);
+    expect(title.classList.contains("font-bold")).toBe(true);
   });
 
   test("works with tailwind-merge", () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,13 @@ export { clsx as cx };
 
 type AbstractCompose = (...params: any) => string;
 
+type ExtractComponentProps<
+  TComponent extends React.ElementType,
+  TCompose extends AbstractCompose,
+> = Omit<React.ComponentProps<TComponent>, "className"> & {
+  className?: Parameters<TCompose>[0];
+};
+
 type ResultProps<
   TComponent extends React.ElementType,
   TProps,
@@ -14,13 +21,9 @@ type ResultProps<
   TCompose extends AbstractCompose,
 > = TProps extends undefined
   ? TExtraProps extends undefined
-    ? Omit<React.ComponentProps<TComponent>, "className"> & {
-        className?: Parameters<TCompose>[0];
-      }
-    : Omit<React.ComponentProps<TComponent>, "className"> & {
-        className?: Parameters<TCompose>[0];
-      } & TExtraProps
-  : TProps;
+    ? ExtractComponentProps<TComponent, TCompose>
+    : ExtractComponentProps<TComponent, TCompose> & TExtraProps
+  : TProps & ExtractComponentProps<TComponent, TCompose> & TExtraProps;
 
 type Template<
   TComponent extends React.ElementType,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,9 @@ type ResultProps<
   ? TExtraProps extends undefined
     ? ExtractComponentProps<TComponent, TCompose>
     : ExtractComponentProps<TComponent, TCompose> & TExtraProps
-  : TProps & ExtractComponentProps<TComponent, TCompose> & TExtraProps;
+  : TExtraProps extends undefined
+    ? TProps & ExtractComponentProps<TComponent, TCompose>
+    : TProps & ExtractComponentProps<TComponent, TCompose> & TExtraProps;
 
 type Template<
   TComponent extends React.ElementType,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary
Fixes #12
The problem with the current generic usage, right now it rewrites the props entirely and potentially makes the composed component unsafe, (by passing props that the component would not accept otherwise) in my opinion the generic should not rewrite the entire type, and instead the types of the component's props should still exist no matter if the user includes them or not.


## Test plan
Most of the tests worked as expected, added a test for cva and asChild usage updated some comments
