### PR TITLE
feat: add additional props support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,5 +5,8 @@
   },
   "parser": "@typescript-eslint/parser",
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
-  "plugins": ["@typescript-eslint"]
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/ban-types": "off"
+  }
 }

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 /*
-!/dist/**/*.{ts,js}
+!/dist/index.d.ts
+!/dist/index.mjs

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Features
 
-- ⚡️ Lightweight — only 0.42kb
+- ⚡️ Lightweight — only 0.44kb
 - ✨ Autocompletion in all editors
 - 🎨 Adapt the style based on props
 - ♻️ Reuse classes with `asChild` prop

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,15 +1,17 @@
 import { swc } from "rollup-plugin-swc3";
 import ts from "rollup-plugin-ts";
 
-const swcPlugin = swc({
-  tsconfig: false,
-  jsc: {
-    parser: {
-      syntax: "typescript",
+const swcPlugin = (minify) =>
+  swc({
+    tsconfig: false,
+    minify,
+    jsc: {
+      parser: {
+        syntax: "typescript",
+      },
+      target: "es2018",
     },
-    target: "es2018",
-  },
-});
+  });
 
 const tsPlugin = ts({ transpiler: "swc" });
 
@@ -26,7 +28,21 @@ const buildEs = ({
     file: output,
     format: "es",
   },
-  plugins: [swcPlugin],
+  plugins: [swcPlugin(false)],
+});
+
+const buildMin = ({
+  input = "src/index.tsx",
+  output = "dist/index.min.mjs",
+  external = ignoreRelative,
+} = {}) => ({
+  input,
+  external,
+  output: {
+    file: output,
+    format: "es",
+  },
+  plugins: [swcPlugin(true)],
 });
 
 const buildTypes = ({
@@ -43,4 +59,4 @@ const buildTypes = ({
   plugins: [tsPlugin],
 });
 
-export default [buildEs(), buildTypes()];
+export default [buildEs(), buildMin(), buildTypes()];

--- a/website/pages/docs/api-reference.mdx
+++ b/website/pages/docs/api-reference.mdx
@@ -2,7 +2,7 @@
 
 List of exports available from `react-twc` package.
 
-## `twc`
+### `twc`
 
 Builds a `twc` component.
 
@@ -12,7 +12,7 @@ import { twc } from "react-twc";
 const Title = twc.h2`font-bold`;
 ```
 
-## `createTwc`
+### `createTwc`
 
 Create a custom instance of `twc`.
 
@@ -26,12 +26,12 @@ const twx = createTwc({
 });
 ```
 
-### Options
+#### Options
 
 - `compose`: The compose function to use. Defaults to `clsx`.
 - `shouldForwardProp`: The function to use to determine if a prop should be forwarded to the underlying component. Defaults to `prop => prop[0] !== "$"`.
 
-## `cx`
+### `cx`
 
 Concatenates class names (an alias of [`clsx`](https://github.com/lukeed/clsx)).
 
@@ -39,4 +39,14 @@ Concatenates class names (an alias of [`clsx`](https://github.com/lukeed/clsx)).
 import { cx } from "react-twc";
 
 const className = cx(classes);
+```
+
+### `TwcComponentProps<Component, Compose = typeof clsx>`
+
+Returns props accepted by a `twc` component. Similar to `React.ComponentProps<"button">` with `asChild` prop and `className` type from `clsx`.
+
+```tsx
+import type { TwcComponentProps } from "react-twc";
+
+type ButtonProps = TwcComponentProps<"button">;
 ```

--- a/website/pages/docs/guides/_meta.json
+++ b/website/pages/docs/guides/_meta.json
@@ -1,4 +1,8 @@
 {
   "as-child-prop": "asChild prop",
-  "class-name-prop": "className prop"
+  "class-name-prop": "className prop",
+  "refs": "Refs",
+  "styling-any-component": "Styling any component",
+  "additional-props": "Additional props",
+  "adapting-based-on-props": "Adapting based on props"
 }

--- a/website/pages/docs/guides/additional-props.mdx
+++ b/website/pages/docs/guides/additional-props.mdx
@@ -1,0 +1,34 @@
+# Additional props
+
+To avoid unnecessary wrappers that just pass on some props to the rendered component or element, you can use the `.attrs` constructor. It allows you to attach additional props (or "attributes") to a component.
+
+## Usage
+
+Create an `input` of type "checkbox" with `twc`:
+
+```ts
+const Checkbox = twc.input.attrs({
+  type: "checkbox",
+})`appearance-none size-4 border-2 border-blue-500 rounded-sm bg-white`;
+```
+
+## Adapting attributes based on props
+
+`attrs` accepts a function to generate attributes based on input props.
+
+In this example, we create an anchor that accepts an `$external` prop and adds `target` and `rel` attributes based on its value.
+
+```ts
+import { twc, TwcComponentProps } from "react-twc";
+
+type AnchorProps = TwcComponentProps<"a"> & { $external?: boolean };
+
+// Accept an $external prop that adds `target` and `rel` attributes if present
+const Anchor = twc.a.attrs<AnchorProps>((props) =>
+  props.$external ? { target: "_blank", rel: "noopener noreferrer" } : {},
+)`appearance-none size-4 border-2 border-blue-500 rounded-sm bg-white`;
+
+render(
+  <Anchor $external href="https://cva.style">Class Variance Authority</Link>
+);
+```

--- a/website/pages/docs/guides/styling-any-component.mdx
+++ b/website/pages/docs/guides/styling-any-component.mdx
@@ -25,3 +25,11 @@ export default () => (
   </HoverCard.Root>
 );
 ```
+
+If you need to specify some default props, you can use [additional props](/guides/additional-props). For example you can define the `sideOffset` by default using `attrs` constructor:
+
+```tsx
+const HoverCardContent = twc(HoverCard.Content).attrs({
+  sideOffset: 5,
+})`data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade w-[300px] rounded-md bg-white p-5 shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] data-[state=open]:transition-all`;
+```

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -47,7 +47,7 @@ const Card = twc.div`rounded-lg border bg-slate-100 text-white shadow-sm`;
 
 With just one single line of code, you can create a reusable component with all these amazing features out-of-the-box:
 
-- ⚡️ Lightweight — only 0.42kb
+- ⚡️ Lightweight — only 0.44kb
 - ✨ Autocompletion in all editors
 - 🎨 Adapt the style based on props
 - ♻️ Reuse classes with `asChild` prop


### PR DESCRIPTION
# Additional props

To avoid unnecessary wrappers that just pass on some props to the rendered component or element, you can use the `.attrs` constructor. It allows you to attach additional props (or "attributes") to a component.

## Usage

Create an `input` of type "checkbox" with `twc`:

```ts
const Checkbox = twc.input.attrs({
  type: "checkbox",
})`appearance-none size-4 border-2 border-blue-500 rounded-sm bg-white`;
```

## Adapting attributes based on props

`attrs` accepts a function to generate attributes based on input props.

In this example, we create an anchor that accepts an `$external` prop and adds `target` and `rel` attributes based on its value.

```ts
import { twc, TwcComponentProps } from "react-twc";

type AnchorProps = TwcComponentProps<"a"> & { $external?: boolean };

// Accept an $external prop that adds `target` and `rel` attributes if present
const Anchor = twc.a.attrs<AnchorProps>((props) =>
  props.$external ? { target: "_blank", rel: "noopener noreferrer" } : {},
)`appearance-none size-4 border-2 border-blue-500 rounded-sm bg-white`;

render(
  <Anchor $external href="https://cva.style">Class Variance Authority</Link>
);
```
