### PR TITLE
fix typo on introduction

### DIFF
--- a/website/pages/docs/introduction.mdx
+++ b/website/pages/docs/introduction.mdx
@@ -24,7 +24,7 @@ const Card = React.forwardRef<
 ));
 ```
 
-You hand up writing lot of lines just to reuse some class names.
+You end up writing lot of lines just to reuse some class names.
 
 `twc` aims to make it easy and more productive, allowing you to focus on building UI instead of writing code.
 


### PR DESCRIPTION
## Summary

Was reading the docs and saw this line:
```
You hand up writing lot of lines just to reuse some class names.
```
pretty sure it should say
```
You end up...
```
anyway, thought i'd make this PR so that it is an easy one click fix

## Test plan

n/a