### PR TITLE
fix(attrs): wrap component props with partial

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,7 +55,7 @@ type FirstLevelTemplate<
    */
   attrs: <TProps = undefined>(
     attrs:
-      | (Omit<React.ComponentProps<TComponent>, "className"> &
+      | (Omit<Partial<React.ComponentProps<TComponent>>, "className"> &
           Record<string, any>)
       | ((
           props: ResultProps<TComponent, TProps, TExtraProps, TCompose>,


### PR DESCRIPTION
You were right. We shouldn't enforce the types, we really only need the autocomplete.