### PR TITLE
Update vscode settings

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -22,14 +22,12 @@ You can enable Tailwind CSS autocompletion inside `twc` using the steps below:
     2. Add the following to your [`settings.json`](https://code.visualstudio.com/docs/getstarted/settings):
 
     ```json
-    {
-      "tailwindCSS.experimental.classRegex": [
-        "twc\\.[^`]+`([^`]*)`",
-        "twc\\(.*?\\).*?`([^`]*)",
+    "tailwindCSS.experimental.classRegex": [
+        "twc\\.[^`]+`([^`]*)`", 
+        "twc\\([^`]*?\\)`([^`]*)`",
         ["twc\\.[^`]+\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
-        ["twc\\(.*?\\).*?\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-      ]
-    }
+        ["twc\\([^`]*?\\).*?\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+    ]
     ```
 
   </Tab>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Updated docs with example of vscode settings. In original docs vscode support is only working on general components like:

```typescript
export const Glass = twc.div`rounded-xl border border-white/15 bg-white/10 p-4 backdrop-blur-sm shadow-lg drop-shadow-lg`;
```

But with more complex components when you have to use twc as a function it doesn't work:

```typescript
export const NavBar = twc(
  Glass
)`fixed top-0 left-0 w-full text-center border-t-0 rounded-t-none flex flex-row content-start justify-start`;
```

This pull request aims to update docs, so that new users of libraries will have better IDE support

## Test plan

Use new settings and check if tailwind provides correct autocomplete for more complex twc components

![CleanShot 2024-05-13 at 15 55 29@2x](https://github.com/gregberge/twc/assets/3639568/9c5032e4-3a11-4593-b9c2-f98682445cdd)

