### PR TITLE
fix component props from attrs not respecting provided transient props

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -4,9 +4,9 @@ description: "Sets up Node.js and runs install"
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v2.2.4
+    - uses: pnpm/action-setup@v4
       with:
-        version: 8
+        version: 9
 
     - name: Setup Node.js
       uses: actions/setup-node@v3

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -279,4 +279,20 @@ describe("twc", () => {
     expect(svg).toBeDefined();
     expect(svg.tagName).toBe("SVG");
   });
+
+  test("component props from attrs should respect provided transient props", () => {
+    type ButtonProps = TwcComponentProps<"button"> & {
+      variant: "primary" | "secondary";
+    };
+    const Button = twc.button
+      .transientProps(["variant"])
+      .attrs<ButtonProps>(({ type = "button", variant }) => {
+        expect(variant).toBe("primary");
+        return { type };
+      })`text-xl`;
+    render(<Button data-testid="button" variant="primary" />);
+
+    const renderedButton = screen.getByTestId("button");
+    expect(renderedButton.getAttribute("variant")).toBeNull();
+  });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -171,7 +171,7 @@ export const createTwc = <TCompose extends AbstractCompose = typeof clsx>(
 
       if (attrs === undefined) {
         template.attrs = (attrs: Attributes) => {
-          return createTemplate(attrs);
+          return createTemplate(attrs, shouldForwardProp);
         };
       }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
**Summary:** This PR addressed a bug when transient props(`transientProps()`) is provided/used with attrs(`attrs()`), the rendered component props is not respecting provided _transient props_.

**Problem:** On [transient props function body](https://github.com/gregberge/twc/blob/main/src/index.tsx#L174), `shouldForwardProp`, an argument that refers to the provided _transientProps_, is not passed along as the result of the execution, so the closure in the next execution, that is used to execute `attrs`, is lost and cannot capture the already defined _transientProps_, resulting in incorrect rendered component props, the props is not filtered by _transientProps_.

**Solution:** Pass along the `transientProps` to the template, so that, it is available when executing `attrs`